### PR TITLE
fix: typo on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This login function provides users to login with DANA Account on the Merchant si
 
 ```php
 
-$generateLoginUrl = \DANA\Auth::generateLoginUrl;
+$generateLoginUrl = \DANA\Auth::generateLoginUrl();
 
 ```
 


### PR DESCRIPTION
i am sorry, there is some function need to add () on readme, to make sure users can use correctly